### PR TITLE
feat: Display air date for unaired episodes

### DIFF
--- a/src/lib/SeasonsListEpisode.svelte
+++ b/src/lib/SeasonsListEpisode.svelte
@@ -24,6 +24,10 @@
 
 	let isHidden: boolean = $state(!!store?.userSettings?.hideSpoilers);
 
+    const isUnaired = $derived(
+      ep.air_date && new Date(ep.air_date).getTime() > new Date().getTime()
+    );
+
 	function updateWatchedEpisode(status?: WatchedStatus, rating?: number) {
 		if (!watchedItem) {
 			console.error(
@@ -203,6 +207,11 @@
 				{Math.round(ep.vote_average * 10) / 10}
 			</span>
 		</div>
+		{#if isUnaired}
+			<span class="episode-air-date"
+				>Airs on {new Date(ep.air_date).toLocaleDateString()}</span
+			>
+		{/if}
 		<span class="overview">{ep.overview}</span>
 	</div>
 	{#if watchedItem}
@@ -308,6 +317,15 @@
 						line-height: 0.7;
 					}
 				}
+			}
+
+			.episode-air-date {
+				font-size: 14px;
+				color: $text-color-accent;
+				padding: 0 2px;
+				text-transform: lowercase;
+				font-variant: small-caps;
+				font-weight: bold;
 			}
 		}
 

--- a/src/lib/SeasonsListEpisode.svelte
+++ b/src/lib/SeasonsListEpisode.svelte
@@ -24,9 +24,9 @@
 
 	let isHidden: boolean = $state(!!store?.userSettings?.hideSpoilers);
 
-    const isUnaired = $derived(
-      ep.air_date && new Date(ep.air_date).getTime() > new Date().getTime()
-    );
+	const isUnaired = $derived(
+		ep.air_date && new Date(ep.air_date).getTime() > new Date().getTime(),
+	);
 
 	function updateWatchedEpisode(status?: WatchedStatus, rating?: number) {
 		if (!watchedItem) {


### PR DESCRIPTION
- Show air date for episodes that are in the future.

### Changes made

This pull request enhances the user experience by displaying the air date for upcoming episodes.

Changes:

Displays Air Date: For episodes with a future air date, the component now displays "Airs on [date]".
Placement: The air date is positioned above the episode description, which is often empty for unaired episodes.
Styling: The air date text is styled to be slightly smaller and uses a muted color to differentiate it from other information.
How to Test:

Navigate to a TV show that has upcoming episodes.
View the list of episodes for a season that has not yet fully aired.
Confirm that episodes with a future air date now display the "Airs on..." text above the description.
Verify that the text is styled correctly (smaller, muted color).
